### PR TITLE
When parsing of a frame succeeds, try parsing another one

### DIFF
--- a/lib/spdy/parser.rb
+++ b/lib/spdy/parser.rb
@@ -46,6 +46,7 @@ module SPDY
       end
 
       def try_parse
+        return if @buffer.length < 1
         type = @buffer[0,1].unpack('C').first >> 7 & 0x01
         pckt = nil
 
@@ -84,6 +85,9 @@ module SPDY
 
         # remove parsed data from the buffer
         @buffer.slice!(0...pckt.num_bytes)
+        
+        # try parsing another frame
+        try_parse
 
       rescue IOError => e
         # rescue partial parse and wait for more data

--- a/lib/spdy/parser.rb
+++ b/lib/spdy/parser.rb
@@ -46,7 +46,7 @@ module SPDY
       end
 
       def try_parse
-        return if @buffer.length < 1
+        return if @buffer.empty?
         type = @buffer[0,1].unpack('C').first >> 7 & 0x01
         pckt = nil
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -44,6 +44,13 @@ describe SPDY::Parser do
     fired.should be_true
   end
 
+  it "should parse multiple frames in a single buffer" do
+    fired = 0
+    s.on_body { |stream_id, d| fired += 1 }
+    s << DATA*2
+    fired.should == 2
+  end
+
   context "CONTROL" do
     it "should parse SYN_STREAM packet" do
       fired = false


### PR DESCRIPTION
This can happen when the underlying transport has a large chunk size.
