### PR TITLE
Return parsed packets

### DIFF
--- a/lib/spdy/parser.rb
+++ b/lib/spdy/parser.rb
@@ -89,9 +89,10 @@ module SPDY
 
         # remove parsed data from the buffer
         @buffer.slice!(0...pckt.num_bytes)
-        
+ 
         # try parsing another frame
-        try_parse
+        another_packet = try_parse || [nil]
+        ([pckt] + another_packet).compact
 
       rescue IOError => e
         # rescue partial parse and wait for more data

--- a/lib/spdy/parser.rb
+++ b/lib/spdy/parser.rb
@@ -33,19 +33,13 @@ module SPDY
     private
 
       def unpack_control(pckt, data)
-        pckt.read(data)
-
-        headers = {}
-        if pckt.data.size > 0
-          data = @zlib_session.inflate(pckt.data.to_s)
-          headers = NV.new.read(data).to_h
-        end
+        pckt.parse(data)
 
         if @on_headers_complete
           @on_headers_complete.call(pckt.header.stream_id.to_i,
                                     (pckt.associated_to_stream_id.to_i rescue nil),
                                     (pckt.pri.to_i rescue nil),
-                                    headers)
+                                    pckt.uncompressed_data.to_h)
         end
       end
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -54,7 +54,6 @@ describe SPDY::Parser do
 
   it "should return the parsed packets" do
     packets = (s << (SYN_REPLY+DATA))
-
     packets.length.should == 2
 
     packets[0].class.should == SPDY::Protocol::Control::SynReply

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -44,11 +44,24 @@ describe SPDY::Parser do
     fired.should be_true
   end
 
+
   it "should parse multiple frames in a single buffer" do
     fired = 0
     s.on_body { |stream_id, d| fired += 1 }
     s << DATA*2
     fired.should == 2
+  end
+
+  it "should return the parsed packets" do
+    packets = (s << (SYN_REPLY+DATA))
+
+    packets.length.should == 2
+
+    packets[0].class.should == SPDY::Protocol::Control::SynReply
+    packets[0].uncompressed_data.to_h['status'].should == '200 OK'
+    
+    packets[1].class.should == SPDY::Protocol::Data::Frame
+    packets[1].data.should == 'This is SPDY.'
   end
 
   context "CONTROL" do


### PR DESCRIPTION
This changes Parser#try_parse to return an array of the parsed packets after parsing.

I found it very useful when testing the responses of my SPDY server.
The return value should probably be adjusted to [nil](or an empty array?) in the return statements above it in order to be consistent.

What are your thoughts?
